### PR TITLE
Only turn off drag/snip when enabling snip/drag

### DIFF
--- a/keyboards/handwired/wylderbuilds/trackball/trackball.c
+++ b/keyboards/handwired/wylderbuilds/trackball/trackball.c
@@ -170,7 +170,7 @@ bool charybdis_get_pointer_sniping_enabled(void) { return g_charybdis_config.is_
 
 void charybdis_set_pointer_sniping_enabled(bool enable) {
     g_charybdis_config.is_sniping_enabled = enable;
-    g_charybdis_config.is_dragscroll_enabled = false; // if we're adjusting sniping, then dragscroll should be false
+    if(enable) g_charybdis_config.is_dragscroll_enabled = false; // if we're adjusting sniping, then dragscroll should be false
     maybe_update_pointing_device_cpi(&g_charybdis_config);
 }
 
@@ -178,7 +178,7 @@ bool charybdis_get_pointer_dragscroll_enabled(void) { return g_charybdis_config.
 
 void charybdis_set_pointer_dragscroll_enabled(bool enable) {
     g_charybdis_config.is_dragscroll_enabled = enable;
-    g_charybdis_config.is_sniping_enabled = false;  // if we're adjusting dragscroll. then sniping should be false
+    if(enable) g_charybdis_config.is_sniping_enabled = false;  // if we're adjusting dragscroll. then sniping should be false
     maybe_update_pointing_device_cpi(&g_charybdis_config);
 }
 


### PR DESCRIPTION
Dragscroll mode should disable sniping mode only when dragscroll mode is being enabled.

Sniping mode should disable dragscroll mode only when sniping mode is being enabled.

<!---

    If you are submitting a Vial-enabled keymap for a keyboard in QMK:

    - Keymaps will not be accepted with VIAL_INSECURE=yes.
    - Avoid changing keyboard-level code if possible. (ex: switching the encoder pins in info.json)
    - Please name your keymap "vial". Personal keymaps are not accepted at this time.
      - If your Vial keymap only works for a specific keyboard revision, place it under that revision's folder. (ex: keyboards/planck/rev6_drop/keymaps/vial and keyboards/planck/ez/glow/keymaps/vial)

    If you are submitting a new keyboard with keymaps:

    - If you are also submitting this keyboard to QMK, please try to submit mostly the same code to both repos if possible.
    - If you are not submitting this keyboard to QMK, only include "default" and "vial" keymaps. VIA firmware can no longer be built by this repository.

    ------

    For all keyboard and keymap submissions:

    As the submitter, you are ultimately responsible for maintaining the keyboards/keymaps you submit.
    Vial contributors will try to fix compilation issues as updates are made, but are not always familiar with and often can't test specific keymaps/keyboards.

    Vial is decentralized, so inclusion in the vial-qmk repository is optional. Unmaintained keymaps/keyboards which are broken and cannot be fixed without extensive rework or strong familiarity with the hardware may be removed from this repository, with or without warning.

    ------

    For core changes, please explain what you are changing and why.

    Before submitting a PR, delete the entirety of this comment and document your changes.
-->
